### PR TITLE
:building_construction: Introduce `human-panic`

### DIFF
--- a/crates/launcher/Cargo.toml
+++ b/crates/launcher/Cargo.toml
@@ -5,6 +5,7 @@ edition.workspace = true
 authors.workspace = true
 
 [dependencies]
+human-panic = "1.2.1"
 
 [target.'cfg(target_os = "windows")'.dependencies]
 windows = { version = "0.51.1", features = [

--- a/crates/launcher/src/main.rs
+++ b/crates/launcher/src/main.rs
@@ -1,8 +1,12 @@
 use std::env::current_exe;
 
+use human_panic::setup_panic;
+
 use v8_killer_launcher::{default_lib_filename, launch};
 
 fn main() {
+    setup_panic!();
+
     // TODO: Support custom lib_filename
     let lib_filename = default_lib_filename().unwrap();
     let mut lib_path = current_exe().unwrap().parent().unwrap().to_path_buf();


### PR DESCRIPTION
## Why?

### Improve experience of developer and user

As a user terminal program, having a good panic output is a good way to improve the user experience and help developers improve their programs.

However, Rust's panic output is very verbose, see the example given by the `human-panic` project for an example of a PullRequest submitted for the same reason the `human-panic` project exists.

### Help hacking with different v8 runtime

For a number of reasons, upstream V8 is updated very quickly.

At the same time, NodeJS and Electron, which are downstream programs of V8, are also changing rapidly, and downstream programs based on V8 tend to co-exist with many versions in the course of users' use. For hacking V8 behavior, it is very important to have a good panic output returned from the user - because it is possible to get the changes of different versions of V8, and it is very normal that method A exists in version x of V8, but not in version y of V8.

### Figure out how users actually use your project

This does not appear to be very important.

Users may use your program in ways you wouldn't expect. You can get the gist from the panic message, but I don't think that's the goal of `human-panic`.

To get to that point, I recommend you consider introducing `tracing` and `tracing-subscriber` to your project.
