### PR TITLE
highly experimental macOS hijacking for v8killer launcher

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -8,12 +8,24 @@ jobs:
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
-        os: [ ubuntu-latest, windows-latest ]
+        os: [ ubuntu-latest, windows-latest, macos-latest ]
     steps:
       - uses: actions/checkout@v4
-      - uses: dtolnay/rust-toolchain@stable
-      - name: Build
+      - name: Build for Windows/Linux
+        if: matrix.os == 'ubuntu-latest' || matrix.os == 'windows-latest'
         run: cargo build --verbose --release
+      - name: Build for macOS
+        if: matrix.os == 'macos-latest'
+        run: |
+          rustup target add aarch64-apple-darwin x86_64-apple-darwin
+          cargo build --verbose --release --target aarch64-apple-darwin
+          cargo build --verbose --release --target x86_64-apple-darwin
+          lipo -create -output target/libv8_killer_core.dylib \
+            target/aarch64-apple-darwin/release/libv8_killer_core.dylib \
+            target/x86_64-apple-darwin/release/libv8_killer_core.dylib
+          lipo -create -output target/v8_killer_launcher \
+            target/aarch64-apple-darwin/release/v8_killer_launcher \
+            target/x86_64-apple-darwin/release/v8_killer_launcher
       - name: Upload artifact
         uses: actions/upload-artifact@v3
         with:
@@ -24,3 +36,5 @@ jobs:
             target/release/libv8_killer_core.so
             target/release/libv8_killer_launcher.so
             target/release/v8_killer_launcher
+            target/libv8_killer_core.dylib
+            target/v8_killer_launcher

--- a/crates/launcher/src/main.rs
+++ b/crates/launcher/src/main.rs
@@ -10,7 +10,8 @@ fn main() {
     let lib_path_str = lib_path.to_str().unwrap();
 
     let exe = std::env::args().nth(1).expect("no executable provided");
-    let args = std::env::args().skip(2).collect::<Vec<String>>();
+    let args = std::env::args().skip(2).collect::<Vec<_>>();
+    let args = args.iter().map(|s| s.as_str()).collect::<Vec<_>>();
 
     println!("[*] Executable: {}", exe);
     println!("[*] Args: {:?}", args);


### PR DESCRIPTION
**WARNING: Still very unstable and not-process-elegant** :P 

I assume that user have installed Xcode on their Mac computers which contains `codesign` for re-signing the target executable program. Then we copy the entire application bundle to a temporary direction to modify the program to hijacking v8killer. Then sign and run, that's it.

> 写英语好辛苦还是用中文再写一遍吧（雾）
> 反正现阶段我能实现的是对目标应用程序（通常是 App Bundle）拷贝到一个临时目录然后作注入和签名操作（这个过程也许可以被缓存？）最后再执行修改后的产物，理论上只要签名成功应该就可以被执行了。
> 然鹅现实很骨感（）
> 签名过程还是有问题，不过还是为了集思广益提前开这个草稿 PR ，我会把详细的情况发到评论里面，可以帮忙参考一下。