### PR TITLE
Some enhancements for developer experiences

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -9,3 +9,13 @@ resolver = "2"
 version = "0.1.0"
 edition = "2021"
 authors = ["ShellWen <me@shellwen.com>"]
+
+[workspace.dependencies]
+clap = { version = "4.5", features = ["derive"] }
+tracing = "0.1"
+tracing-subscriber = "0.3"
+
+[profile.release]
+opt-level = "z"
+lto = true
+codegen-units = 1

--- a/crates/core/Cargo.toml
+++ b/crates/core/Cargo.toml
@@ -8,15 +8,17 @@ authors.workspace = true
 crate-type = ["cdylib"]
 
 [dependencies]
-frida-gum = { version = "0.13.2", features = ["auto-download", "invocation-listener"] }
-lazy_static = "1.4.0"
-ctor = "0.2.4"
-toml = "0.8.1"
-serde = { version = "1.0.188", features = ["derive"] }
-regex = "1.10.2"
+ctor = "0.2"
+frida-gum = { version = "0.13", features = ["auto-download", "invocation-listener"] }
+once_cell = "1.19"
+regex = "1.10"
+serde = { version = "1.0", features = ["derive"] }
+toml = "0.8"
+tracing = { workspace = true }
+tracing-subscriber = { workspace = true }
 
 [target.'cfg(target_os = "windows")'.dependencies]
-windows = { version = "0.51.1", features = [
+windows = { version = "0.54", features = [
     "Win32_Foundation",
     "Win32_System_Console",
 ] }

--- a/crates/core/src/config.rs
+++ b/crates/core/src/config.rs
@@ -15,7 +15,7 @@ pub(crate) struct ConfigRule {
     pub(crate) processors: Vec<SourceProcessor>,
 }
 
-#[derive(Deserialize, Debug)]
+#[derive(Deserialize, Default, Debug)]
 pub(crate) struct Config {
     #[serde(default)]
     pub(crate) identifiers: Identifiers,

--- a/crates/core/src/core.rs
+++ b/crates/core/src/core.rs
@@ -1,5 +1,7 @@
 use std::ops::Deref;
 
+use tracing::*;
+
 use crate::config::Config;
 use crate::matcher::SourceMatcher;
 use crate::source::Source;
@@ -23,17 +25,14 @@ pub(crate) unsafe fn process_script(
         let (rule_name, rule) = rule_item;
         let is_match = &rule.matcher.deref().matches(&source);
         if *is_match {
-            println!(
-                "[*] Rule {} matched in {}",
-                rule_name, &source.resource_name
-            );
+            info!("Rule {} matched in {}", rule_name, &source.resource_name);
             let processors = &rule.processors;
             processors.iter().for_each(|processor_item| {
                 let processor = processor_item;
                 let result = processor.process(&mut source);
                 if result.is_err() {
-                    println!(
-                        "[!] Processor {:#?} process failed: {}",
+                    error!(
+                        "Processor {:#?} process failed: {}",
                         processor,
                         result.err().unwrap()
                     );

--- a/crates/core/src/core.rs
+++ b/crates/core/src/core.rs
@@ -17,6 +17,7 @@ pub(crate) unsafe fn process_script(
     let isolate = v8_context_get_isolate(v8_context);
     let resource_name = string_from_local_string(isolate, (*v8_source)._resource_name);
     let source_string = string_from_local_string(isolate, (*v8_source)._source_string);
+    debug!("Processing source: {resource_name}");
     let mut source = Source {
         resource_name,
         source_string,

--- a/crates/core/src/lib.rs
+++ b/crates/core/src/lib.rs
@@ -7,10 +7,12 @@ use once_cell::sync::Lazy;
 use tracing::*;
 use tracing_subscriber::fmt::time::uptime;
 
-use crate::config::{Config, ReadFromFile};
 use crate::core::process_script;
-use crate::identifier::Identifier;
 use crate::v8_sys::{V8Context, V8Source};
+use crate::{
+    config::{Config, ReadFromFile},
+    identifier::Identifier,
+};
 
 mod config;
 mod core;
@@ -22,7 +24,24 @@ mod v8_sys;
 
 static GUM: Lazy<Gum> = Lazy::new(|| unsafe { Gum::obtain() });
 
-static mut CONFIG: Option<Config> = None;
+static CONFIG: Lazy<Config> = Lazy::new(|| {
+    let config_file_path = std::env::var("V8_KILLER_CONFIG_FILE_PATH");
+    match config_file_path {
+        Ok(config_file_path) => {
+            info!("V8_KILLER_CONFIG_FILE_PATH: {config_file_path}");
+            let path = Path::new(&config_file_path);
+            let config = Config::load_from_toml(path);
+            info!("Read Config success: {config:#?}");
+            config
+        }
+        Err(_) => {
+            warn!("V8_KILLER_CONFIG_FILE_PATH not found");
+            warn!("Please set V8_KILLER_CONFIG_FILE_PATH to config file path");
+            warn!("V8 Killer will only tracing source code without config file");
+            Default::default()
+        }
+    }
+});
 
 // v8::ScriptCompiler::CompileFunctionInternal(v8::Local<v8::Context>, v8::ScriptCompiler::Source*, unsigned long, v8::Local<v8::String>*, unsigned long, v8::Local<v8::Object>*, v8::ScriptCompiler::CompileOptions, v8::ScriptCompiler::NoCacheReason, v8::Local<v8::ScriptOrModule>*)
 struct V8ScriptCompilerCompileFunctionInternalListener;
@@ -38,8 +57,7 @@ impl InvocationListener for V8ScriptCompilerCompileFunctionInternalListener {
             let context = frida_context.arg(1) as *const V8Context;
             #[cfg(target_os = "windows")]
             let source = frida_context.arg(2) as *mut V8Source;
-            let config = CONFIG.as_ref().unwrap();
-            process_script(config, context, source);
+            process_script(&CONFIG, context, source);
         }
     }
 
@@ -48,8 +66,10 @@ impl InvocationListener for V8ScriptCompilerCompileFunctionInternalListener {
 
 #[ctor]
 fn init() {
-    tracing_subscriber::fmt().with_timer(uptime()).init();
-    info!("V8 Killer has been injected and started!");
+    tracing_subscriber::fmt()
+        .with_timer(uptime())
+        .with_max_level(tracing::Level::DEBUG)
+        .init();
 
     // Fix no output in the Windows GUI subsystem programs
     // See also: [#11](https://github.com/ShellWen/v8_killer/issues/11)
@@ -60,51 +80,35 @@ fn init() {
         let _ = AttachConsole(ATTACH_PARENT_PROCESS);
     }
 
-    // 读取环境变量
-    let config_file_path = std::env::var("V8_KILLER_CONFIG_FILE_PATH");
-    match config_file_path {
-        Ok(config_file_path) => {
-            info!("V8_KILLER_CONFIG_FILE_PATH: {}", config_file_path);
-            let path = Path::new(&config_file_path);
-            let config = Config::load_from_toml(path);
-            info!("Read Config success");
-            info!("Config: {:?}", config);
-            unsafe {
-                CONFIG = Some(config);
-            }
-            let mut interceptor = Interceptor::obtain(&GUM);
+    info!("V8 Killer has been injected and started!");
 
-            interceptor.begin_transaction();
+    let mut interceptor = Interceptor::obtain(&GUM);
 
-            let v8_script_compiler_compile_function_internal = unsafe { CONFIG.as_ref().unwrap() }
-                .identifiers
-                .V8_SCRIPT_COMPILER_COMPILE_FUNCTION_INTERNAL
-                .identify();
+    interceptor.begin_transaction();
 
-            match v8_script_compiler_compile_function_internal {
-                None => {
-                    warn!("v8_script_compiler_compile_function_internal not found")
-                }
-                Some(addr) => {
-                    info!(
-                        "v8_script_compiler_compile_function_internal found: {:?}",
-                        addr.0
-                    );
-                    let mut v8_script_compiler_compile_function_internal_listener =
-                        V8ScriptCompilerCompileFunctionInternalListener;
-                    interceptor.attach(
-                        addr,
-                        &mut v8_script_compiler_compile_function_internal_listener,
-                    );
-                }
-            }
+    let v8_script_compiler_compile_function_internal = CONFIG
+        .identifiers
+        .V8_SCRIPT_COMPILER_COMPILE_FUNCTION_INTERNAL
+        .identify();
 
-            interceptor.end_transaction();
+    match v8_script_compiler_compile_function_internal {
+        None => {
+            error!("v8_script_compiler_compile_function_internal not found");
+            error!("source processing will not work properly");
         }
-        Err(_) => {
-            warn!("V8_KILLER_CONFIG_FILE_PATH not found");
-            warn!("Please set V8_KILLER_CONFIG_FILE_PATH to config file path");
-            warn!("Without config file, V8 Killer will do nothing");
+        Some(addr) => {
+            info!(
+                "v8_script_compiler_compile_function_internal found: {:?}",
+                addr.0
+            );
+            let mut v8_script_compiler_compile_function_internal_listener =
+                V8ScriptCompilerCompileFunctionInternalListener;
+            interceptor.attach(
+                addr,
+                &mut v8_script_compiler_compile_function_internal_listener,
+            );
         }
     }
+
+    interceptor.end_transaction();
 }

--- a/crates/core/src/v8_sys.rs
+++ b/crates/core/src/v8_sys.rs
@@ -77,8 +77,6 @@ type v8__String__NewFromUtf8 = unsafe extern "C" fn(
 
 pub(crate) unsafe fn v8_context_get_isolate(context: *const V8Context) -> *const V8Isolate {
     let v8_context_get_isolate_ptr = CONFIG
-        .as_ref()
-        .unwrap()
         .identifiers
         .V8_CONTEXT_GET_ISOLATE
         .identify()
@@ -93,13 +91,7 @@ pub(super) unsafe fn v8_string_utf8_length(
     this: *const V8String,
     isolate: *const V8Isolate,
 ) -> usize {
-    let v8_string_utf8_length_ptr = CONFIG
-        .as_ref()
-        .unwrap()
-        .identifiers
-        .V8_STRING_UTF8LENGTH
-        .identify()
-        .unwrap();
+    let v8_string_utf8_length_ptr = CONFIG.identifiers.V8_STRING_UTF8LENGTH.identify().unwrap();
     let v8_string_utf8_length_func: v8__String__Utf8Length =
         std::mem::transmute(v8_string_utf8_length_ptr.0);
 
@@ -114,13 +106,7 @@ pub(crate) unsafe fn v8_string_write_utf8(
     nchars_ref: *mut usize,
     options: c_int,
 ) -> c_int {
-    let v8_string_write_utf8_ptr = CONFIG
-        .as_ref()
-        .unwrap()
-        .identifiers
-        .V8_STRING_WRITE_UTF8
-        .identify()
-        .unwrap();
+    let v8_string_write_utf8_ptr = CONFIG.identifiers.V8_STRING_WRITE_UTF8.identify().unwrap();
     let v8_string_write_utf8_func: v8__String__WriteUtf8 =
         std::mem::transmute(v8_string_write_utf8_ptr.0);
 
@@ -134,8 +120,6 @@ pub(crate) unsafe fn v8_string_new_from_utf8(
     length: i32,
 ) -> V8Local<V8String> {
     let v8_string_new_from_utf8_ptr = CONFIG
-        .as_ref()
-        .unwrap()
         .identifiers
         .V8_STRING_NEW_FROM_UTF8
         .identify()

--- a/crates/launcher/Cargo.toml
+++ b/crates/launcher/Cargo.toml
@@ -5,9 +5,12 @@ edition.workspace = true
 authors.workspace = true
 
 [dependencies]
+clap = { workspace = true }
+tracing = { workspace = true }
+tracing-subscriber = { workspace = true }
 
 [target.'cfg(target_os = "windows")'.dependencies]
-windows = { version = "0.51.1", features = [
+windows = { version = "0.54", features = [
     "Win32_System_Threading",
     "Win32_System_Console",
     "Win32_System_Memory",

--- a/crates/launcher/src/main.rs
+++ b/crates/launcher/src/main.rs
@@ -11,15 +11,24 @@ use v8_killer_launcher::{default_lib_filename, launch};
 #[command(version, about, long_about = None)]
 struct Arguments {
     /// Custom dynamic library to inject
-    #[clap(long)]
+    #[arg(long)]
     lib_name: Option<String>,
+    /// Custom configuration file, will pass to the executable by environment variable `V8_KILLER_CONFIG_FILE_PATH`
+    #[arg(long)]
+    config: Option<String>,
+    /// The executable to launch and inject dynamic library
     executable: String,
+    /// The arguments for the executable
+    #[arg(last = true)]
     arguments: Vec<String>,
 }
 
 fn main() {
     tracing_subscriber::fmt().with_timer(uptime()).init();
     let args = Arguments::parse();
+    if let Some(config) = &args.config {
+        std::env::set_var("V8_KILLER_CONFIG_FILE_PATH", config);
+    }
     let lib_filename = if let Some(lib_name) = args.lib_name {
         lib_name
     } else if let Ok(lib_name) = default_lib_filename() {
@@ -32,12 +41,8 @@ fn main() {
     let lib_path = current_exe().unwrap().parent().unwrap().join(lib_filename);
     let lib_path_str = lib_path.to_str().unwrap();
 
-    let exe = std::env::args().nth(1).expect("no executable provided");
-    let args = std::env::args().skip(2).collect::<Vec<_>>();
-    let args = args.iter().map(|s| s.as_str()).collect::<Vec<_>>();
-
-    info!("Executable: {}", exe);
-    info!("Args: {:?}", args);
+    info!("Executable: {}", args.executable);
+    info!("Args: {:?}", args.arguments);
     info!("Core lib path: {}", lib_path_str);
-    launch(lib_path_str, &exe, &args);
+    launch(lib_path_str, &args.executable, args.arguments.as_slice());
 }

--- a/crates/launcher/src/main.rs
+++ b/crates/launcher/src/main.rs
@@ -1,20 +1,43 @@
+use clap::*;
+use tracing::*;
+use tracing_subscriber::fmt::time::uptime;
+
 use std::env::current_exe;
 
 use v8_killer_launcher::{default_lib_filename, launch};
 
+/// A simple launcher/injector for V8 Killer
+#[derive(Parser, Debug)]
+#[command(version, about, long_about = None)]
+struct Arguments {
+    /// Custom dynamic library to inject
+    #[clap(long)]
+    lib_name: Option<String>,
+    executable: String,
+    arguments: Vec<String>,
+}
+
 fn main() {
-    // TODO: Support custom lib_filename
-    let lib_filename = default_lib_filename().unwrap();
-    let mut lib_path = current_exe().unwrap().parent().unwrap().to_path_buf();
-    lib_path.push(lib_filename);
+    tracing_subscriber::fmt().with_timer(uptime()).init();
+    let args = Arguments::parse();
+    let lib_filename = if let Some(lib_name) = args.lib_name {
+        lib_name
+    } else if let Ok(lib_name) = default_lib_filename() {
+        lib_name.to_owned()
+    } else {
+        error!("Can't get default dynamic library name, your platform may not be supported.");
+        error!("You can try to specify the dynamic library manually by setting the `--lib-name` argument.");
+        std::process::exit(1)
+    };
+    let lib_path = current_exe().unwrap().parent().unwrap().join(lib_filename);
     let lib_path_str = lib_path.to_str().unwrap();
 
     let exe = std::env::args().nth(1).expect("no executable provided");
     let args = std::env::args().skip(2).collect::<Vec<_>>();
     let args = args.iter().map(|s| s.as_str()).collect::<Vec<_>>();
 
-    println!("[*] Executable: {}", exe);
-    println!("[*] Args: {:?}", args);
-    println!("[*] Core lib path: {}", lib_path_str);
+    info!("Executable: {}", exe);
+    info!("Args: {:?}", args);
+    info!("Core lib path: {}", lib_path_str);
     launch(lib_path_str, &exe, &args);
 }


### PR DESCRIPTION
- Replaced `println!` macro with [`tracing`](https://crates.io/crates/tracing) logging framework, which brought fancy logging text: ![image](https://github.com/ShellWen/v8_killer/assets/39523898/e3aa5223-743b-4fd3-8053-861835a8506c)
- Use `clap` crate to parse arguments for launcher, now you can get a pretty help message, passing config file through an argument without polluting the environment variable: 
![image](https://github.com/ShellWen/v8_killer/assets/39523898/eaa3db8d-9521-4e2a-8362-d642b0eb4669)
- Replaced [`lazy_static`](https://crates.io/crates/lazy_static) crate with [`once_cell`](https://crates.io/crates/once_cell) crate, which is safer and faster.
- Upgraded some crates
- ...other minimal changes you can review.